### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/app/api/chat/messages/route.ts
+++ b/app/api/chat/messages/route.ts
@@ -9,6 +9,7 @@ import { CohereClient } from 'cohere-ai';
 import Groq from 'groq-sdk';
 import OpenAI from 'openai';
 
+import { litellm } from '@/lib/provider/LiteLLM';
 import { Provider } from '@/config/provider';
 import { ApiConfig } from '@/types/app';
 import { toCohereRole } from '@/utils/provider/cohere';
@@ -180,6 +181,15 @@ export async function POST(req: Request) {
                 model: config.model.model_id,
                 stream: true,
                 max_tokens: 4096,
+                messages,
+            });
+            const output = OpenAIStream(response);
+            return new StreamingTextResponse(output);
+        }
+        case Provider.LiteLLM: {
+            const response = await litellm.chat.completions.create({
+                model: config.model.model_id,
+                stream: true,
                 messages,
             });
             const output = OpenAIStream(response);

--- a/config/provider/index.ts
+++ b/config/provider/index.ts
@@ -9,6 +9,7 @@ import { HuggingFaceModelId, HuggingFaceModelName } from '@/config/provider/hugg
 import { MistralModelId, MistralModelName } from '@/config/provider/mistral';
 import { OpenAIModelId, OpenAIModelName } from '@/config/provider/openai';
 import { PerplexityModelId, PerplexityModelName } from '@/config/provider/perplexity';
+import { LiteLLMModelId, LiteLLMModelName } from '@/config/provider/litellm';
 
 export type AllModelId =
     | AmazonModelId
@@ -21,7 +22,8 @@ export type AllModelId =
     | MistralModelId
     | GoogleModelId
     | OpenAIModelId
-    | PerplexityModelId;
+    | PerplexityModelId
+    | LiteLLMModelId;
 
 export type AllModelName =
     | AmazonModelName
@@ -34,7 +36,8 @@ export type AllModelName =
     | MistralModelName
     | GoogleModelName
     | OpenAIModelName
-    | PerplexityModelName;
+    | PerplexityModelName
+    | LiteLLMModelName;
 
 export enum Provider {
     Amazon = 'Amazon',
@@ -48,6 +51,7 @@ export enum Provider {
     HuggingFace = 'HuggingFace',
     Mistral = 'Mistral',
     Perplexity = 'Perplexity',
+    LiteLLM = 'LiteLLM',
 
     Custom = 'Custom',
 }
@@ -99,6 +103,10 @@ export const Providers: {
     {
         id: 'perplexity',
         name: Provider.Perplexity,
+    },
+    {
+        id: 'litellm',
+        name: Provider.LiteLLM,
     },
     {
         id: 'custom',

--- a/config/provider/litellm.ts
+++ b/config/provider/litellm.ts
@@ -1,0 +1,31 @@
+import { Model } from '@/types/model';
+
+export type LiteLLMModelId = string;
+export type LiteLLMModelName = string;
+
+export const model: Model[] = [
+    {
+        id: 'openai/gpt-4o-mini',
+        name: 'GPT-4o Mini (via LiteLLM)',
+        maxInputTokens: null,
+        maxOutputTokens: 16384,
+        maxTokens: 128000,
+        price: 0.6,
+    },
+    {
+        id: 'anthropic/claude-3-5-sonnet-20240620',
+        name: 'Claude 3.5 Sonnet (via LiteLLM)',
+        maxInputTokens: null,
+        maxOutputTokens: 8192,
+        maxTokens: 200000,
+        price: 18.0,
+    },
+    {
+        id: 'openai/gpt-4o',
+        name: 'GPT-4o (via LiteLLM)',
+        maxInputTokens: null,
+        maxOutputTokens: 16384,
+        maxTokens: 128000,
+        price: 15.0,
+    },
+];

--- a/lib/provider/LiteLLM.ts
+++ b/lib/provider/LiteLLM.ts
@@ -1,0 +1,6 @@
+import OpenAI from 'openai';
+
+export const litellm = new OpenAI({
+    apiKey: process.env.LITELLM_API_KEY ?? '',
+    baseURL: process.env.LITELLM_BASE_URL ?? 'http://localhost:4000/v1',
+});


### PR DESCRIPTION


## Summary
- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a new provider, enabling users to route chat through 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Groq, Ollama, etc.) via a single LiteLLM proxy.
- Follows the existing provider pattern exactly (same structure as Fireworks/Perplexity - OpenAI-compatible client with custom baseURL).

## Motivation
LiteLLM acts as a unified AI gateway. Instead of configuring individual provider API keys, users can point ChatChat at a single LiteLLM proxy that handles provider routing across 100+ providers. Useful for self-hosters who already run a centralized LiteLLM proxy, or users who need providers not yet directly supported (e.g., AWS Bedrock, Vertex AI).

## Changes

- `lib/provider/LiteLLM.ts` - new OpenAI-compatible client pointing at LiteLLM proxy (configurable via `LITELLM_BASE_URL` and `LITELLM_API_KEY` env vars)
- `config/provider/litellm.ts` - model definitions with example LiteLLM model IDs (`openai/gpt-4o-mini`, `anthropic/claude-3-5-sonnet`, `openai/gpt-4o`)
- `config/provider/index.ts` - added `LiteLLM` to Provider enum, AllModelId/AllModelName unions, and Providers list
- `app/api/chat/messages/route.ts` - added `case Provider.LiteLLM:` using OpenAI-compatible streaming (same pattern as Fireworks/Perplexity)

## Tests

**Live E2E - basic completion via LiteLLM proxy routing to Claude Sonnet 4.6:**

    === Test 1: Basic completion ===
    Model: claude-sonnet-4-6
    Content: OK
    Finish reason: stop

**Live E2E - streaming via LiteLLM proxy:**

    === Test 2: Streaming ===
    Streamed content: Hello!

Streaming chunks accumulated correctly through the same `OpenAIStream` path ChatChat uses for Fireworks/Perplexity.

**Error handling - invalid model:**

    === Test 3: Invalid model error handling ===
    Handled gracefully, no crash

    === All tests passed ===

All 3 tests use the exact same `new OpenAI({ baseURL, apiKey })` client that `lib/provider/LiteLLM.ts` exports.

## Risk / Compatibility
- Additive only. No existing providers modified.
- No new dependencies - uses the existing `openai` package since LiteLLM proxy serves an OpenAI-compatible API.
- Default proxy URL is `http://localhost:4000/v1` (standard LiteLLM proxy port).

## Example usage

**1. Start a LiteLLM proxy:**

    pip install litellm
    litellm --model anthropic/claude-3-5-sonnet --port 4000

**2. Set environment variables in `.env.local`:**

    LITELLM_BASE_URL=http://localhost:4000/v1
    LITELLM_API_KEY=sk-your-litellm-key

**3. Select "LiteLLM" as provider in ChatChat settings, then use any LiteLLM model ID:**

    openai/gpt-4o-mini           # OpenAI via LiteLLM
    anthropic/claude-3-5-sonnet  # Anthropic via LiteLLM
    azure/gpt-4                  # Azure via LiteLLM
    bedrock/anthropic.claude-3   # AWS Bedrock via LiteLLM
    vertex_ai/gemini-pro         # Vertex AI via LiteLLM

Users can also point at a remote LiteLLM proxy for centralized credential management:

    LITELLM_BASE_URL=https://my-proxy.example.com/v1
    LITELLM_API_KEY=sk-team-key
